### PR TITLE
[feat] Create Input Component

### DIFF
--- a/src/components/common/Button/Button.module.css
+++ b/src/components/common/Button/Button.module.css
@@ -3,15 +3,15 @@
   height: 69px;
   border-radius: var(--border-radius-lg);
   font-weight: var(--text-weight-bold);
-  font-size: var(--text-lg);
-  color: var(--subColor-lightYello4);
-  background: var(--mainColor-orange1);
+  font-size: var(--text-size-lg);
+  color: var(--grayscale-white);
+  background: var(--color-main-orange-700);
   box-shadow: var(--shadow-default);
 }
 
 .button:active {
-  background: var(--button-active);
-  transition: all 0.5s;
+  background: var(--color-main-active);
+  transition: var(--transition-fast);
 }
 
 .sm {

--- a/src/components/common/HeroCard/HeroCard.module.css
+++ b/src/components/common/HeroCard/HeroCard.module.css
@@ -15,10 +15,10 @@
   top: 1%;
   bottom: 93%;
   font-weight: var(--text-weight-bold);
-  font-size: var(--text-base);
+  font-size: var(--text-size-base);
   line-height: 19px;
   align-items: center;
-  color: var(--grayScale-dark);
+  color: var(--grayscale-black);
 }
 
 .cartoonize {
@@ -48,7 +48,7 @@
   top: 76%;
   bottom: 12%;
   font-weight: var(--text-weight-bold);
-  font-size: var(--text-lg);
+  font-size: var(--text-size-lg);
   line-height: 24px;
   align-items: center;
 }
@@ -60,7 +60,6 @@
   top: 86%;
   bottom: 2%;
   font-weight: var(--text-weight-light);
-  font-size: var(--text-sm);
-  line-height: 17px;
+  font-size: var(--text-size-sm);
   align-items: center;
 }

--- a/src/components/common/Input/Input.module.css
+++ b/src/components/common/Input/Input.module.css
@@ -1,0 +1,105 @@
+.container {
+  position: relative;
+  width: fit-content;
+}
+
+.lgInput {
+  display: block;
+  padding: 20px 29px 20px 32px;
+  width: 522px;
+  height: 69px;
+  font-size: var(--text-size-lg);
+  font-weight: var(--text-weight-bold);
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  background: var(--grayscale-white);
+  box-shadow: 1px 3px 4px rgba(0, 0, 0, 0.25);
+  border-radius: var(--border-radius-lg);
+}
+
+.lgLabel {
+  color: var(--grayscale-darkgray);
+  position: absolute;
+  left: 32px;
+  top: 15px;
+  font-size: var(--text-size-lg);
+  font-weight: var(--text-weight-bold);
+  transition: var(--transition-fast) ease all;
+}
+
+/* .lgInput:focus {
+  outline: none;
+  box-shadow: 0 0 0 6px var(--color-main-orange-700);
+} */
+
+.lgInput:focus ~ .lgLabel,
+.lgInput:valid ~ .lgLabel {
+  position: absolute;
+  left: 32px;
+  top: 0;
+  font-size: var(--text-size-md);
+  font-weight: var(--text-weight-bold);
+  transition: var(--transition-fast) ease all;
+}
+
+/**** size ****/
+.sm {
+  height: 39px;
+  width: 250px;
+  padding-left: 20px;
+  font-size: var(--text-size-md);
+  border-radius: var(--border-radius-sm);
+}
+
+.sm:focus ~ .smLabel,
+.sm:valid ~ .smLabel {
+  position: absolute;
+  left: 40px;
+  top: -26px;
+  font-size: var(--text-size-sm);
+  font-weight: var(--text-weight-bold);
+  transition: var(--transition-fast) ease all;
+}
+
+.smLabel {
+  position: absolute;
+  left: 40px;
+  top: 10px;
+  font-size: var(--text-size-sm);
+}
+
+.md {
+  height: 41px;
+  width: 343px;
+  padding-left: 22px;
+  border-radius: var(--border-radius-sm);
+}
+
+.md:focus ~ .mdLabel,
+.md:valid ~ .mdLabel {
+  position: absolute;
+  left: 46px;
+  top: -26px;
+  font-size: var(--text-size-sm);
+}
+
+.mdLabel {
+  position: absolute;
+  left: 45px;
+  top: 8px;
+  font-size: var(--text-size-base);
+}
+
+/**** Error message ****/
+.noError {
+  display: none;
+}
+
+.error {
+  color: red;
+  font-size: var(--text-size-md);
+  margin-top: 5px;
+  text-align: center;
+}

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,66 @@
+import { Input, InputProps } from '@/components/common';
+
+export default {
+  title: 'Components/Input',
+  component: Input,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+                입력받을 수 있는 input 박스 입니다. 
+            `,
+      },
+    },
+  },
+};
+
+const Template = (args: InputProps) => {
+  return <Input {...args} />;
+};
+
+export const IdInput = Template.bind({});
+IdInput.args = {
+  name: 'id',
+  size: 'lg',
+  labelText: '아이디',
+  validText: '영문자로 시작하는 영문자 또는 숫자 6~20자 아이디를 입력하세요 ',
+};
+
+export const PasswordInput = Template.bind({});
+PasswordInput.args = {
+  name: 'password',
+  size: 'lg',
+  labelText: '비밀번호',
+  validText: '영문, 숫자, 특수문자를 포함한 8~16자 비밀번호를 입력하세요',
+};
+
+export const ConfirmPasswordInput = Template.bind({});
+ConfirmPasswordInput.args = {
+  name: 'confirm',
+  size: 'lg',
+  labelText: '비밀번호확인',
+  validText: '패스워드가 다릅니다',
+};
+
+export const MissionInput = Template.bind({});
+MissionInput.args = {
+  name: 'mission',
+  size: 'md',
+  labelText: '어떤 임무인가요?',
+};
+
+export const HeroNumberInput = Template.bind({});
+HeroNumberInput.args = {
+  name: 'herocode',
+  size: 'sm',
+  labelText: '히어로 넘버',
+  validText: '숫자 4자리로 입력해주세요!',
+};
+
+export const HeroRegisterInput = Template.bind({});
+HeroRegisterInput.args = {
+  name: 'herocode',
+  size: 'lg',
+  labelText: '히어로 넘버를 입력해주세요. 쉿, 비밀~',
+  validText: '숫자 4자리로 입력해주세요!',
+};

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,85 @@
+import styles from './Input.module.css';
+import { useState, useId } from 'react';
+
+export type InputProps = {
+  /**
+   * 어떤 인풋으로 사용할건지 양식을 선택하세요.
+   *
+   */
+  name: 'id' | 'password' | 'mission' | 'herocode' | 'confirm' | 'register';
+  /**
+   * 사용할 인풋의 크기를 선택해주세요 <br>
+   * 기본 크기는 lg 사이즈이고 sm, md 사이즈 인풋을 선택할 수 있습니다.
+   */
+  size: 'sm' | 'md' | 'lg';
+  /**
+   * 인풋에 미리 보여질 텍스트를 입력해주세요 <br>
+   * ex) placeholder에 적을 단어를 적으면 됨
+   */
+  labelText: string;
+  /**
+   * 인풋의 유효성 검사 후 띄울 에러메세지를 입력해주세요.
+   */
+  validText: string;
+  restProps?: unknown[];
+};
+
+export const Input = ({
+  name,
+  size,
+  labelText,
+  validText,
+  ...restProps
+}: InputProps) => {
+  const [inputVal, setInputVal] = useState('');
+  const [valid, setValid] = useState(true);
+
+  const inputId = useId();
+
+  const validateInput = (inputVal) => {
+    const validationRegex = {
+      id: /^[a-z]+[a-z0-9]{5,19}$/g,
+      password:
+        /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,16}$/,
+      confirm: /.*/g,
+      mission: /.*/g,
+      herocode: /^[0-9]{3,4}$/g,
+      register: /.*/g,
+    };
+    setValid(validationRegex[name].test(inputVal));
+  };
+
+  const handleChange = (e) => {
+    setInputVal(e.target.value);
+    validateInput(inputVal);
+  };
+
+  return (
+    <div className={`${styles.container} ${styles[size]}`}>
+      <input
+        id={inputId}
+        name={name}
+        type={name === ('password' | 'confirm') ? 'password' : 'text'}
+        className={`${styles.lgInput} ${styles[size]}`}
+        required
+        autoComplete="false"
+        onChange={handleChange}
+        value={inputVal}
+        maxLength={name === 'herocode' ? '4' : '40'}
+      />
+      <label
+        htmlFor={inputId}
+        className={`${styles.lgLabel} ${
+          size === 'sm' ? styles.smLabel : size === 'md' ? styles.mdLabel : ''
+        }`}
+      >
+        {labelText}
+      </label>
+      <p className={`${valid ? styles.noError : styles.error}`}>{validText}</p>
+    </div>
+  );
+};
+
+Input.defaultProps = {
+  validText: '',
+};

--- a/src/components/common/Input/index.js
+++ b/src/components/common/Input/index.js
@@ -1,0 +1,1 @@
+export * from './Input';

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -2,3 +2,4 @@ export * from './Button';
 export * from './Link';
 export * from './Textarea';
 export * from './HeroCard';
+export * from './Input';


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
close #9 
<br>
<br>

### 3️⃣ 변경 사항
인풋 컴포넌트 구현 
- 로그인, 회원가입, 임무등록, 히어로 선택 값을 입력받을 수 있는 인풋 컴포넌트 
- id, password, mission, herocode, confirm, register 6가지 종류 type
- sm, md, lg 의 3가지 size선택 가능
- 에러메세지 띄울 수 있는 type id, password, herocode 3가지 
- 테스트 결과에서 설명하겠습니다! 
<br>
<br>

### 4️⃣ 테스트 결과
<img width="478" alt="image" src="https://user-images.githubusercontent.com/89028068/206426528-28f414b3-95d9-44ec-b334-2b5bffb62e71.png">
- 로그인 페이지에 사용되는 id 타입의 인풋 컴포넌트 

<img width="497" alt="image" src="https://user-images.githubusercontent.com/89028068/206425965-f134d5ab-a7d5-4d3b-9816-042233e42752.png">
- 포커스되면 초록색 테두리가 나타납니다
- 값을 입력하기 시작하면 validation 검사를 시작하고 유효한 값이 입력될때까지 error 메세지가 사라지지 않습니다. 

<img width="504" alt="image" src="https://user-images.githubusercontent.com/89028068/206426932-7b12afa7-3d31-4bbd-81bd-2bd6a7f4d1ab.png">
- 유효한 값을 입력하면 error 메세지가 사라집니다. 

<img width="375" alt="image" src="https://user-images.githubusercontent.com/89028068/206427242-56ac4917-5bb0-4fea-baa9-50546b3b6e5b.png">
- name props로 mission을 주게되면 에러메세지가 나타나지 않습니다. 
