### PR TITLE
fix: reset heroList, missionList state, when logout

### DIFF
--- a/src/components/common/Nav/Nav.tsx
+++ b/src/components/common/Nav/Nav.tsx
@@ -3,6 +3,7 @@ import { signOut, useSession } from 'next-auth/react';
 import React from 'react';
 import styles from './Nav.module.css';
 import { useRouter } from 'next/router';
+import { useHeroes, useMissions } from '@/hooks';
 
 export type NavProps = {
   /**
@@ -22,22 +23,24 @@ export type NavProps = {
 export const Nav = ({ onButtonClick, currentPage, buttonName }: NavProps) => {
   const router = useRouter();
   const { status } = useSession(); // 세션 유무 파악 가능
+  const { resetHeroList } = useHeroes();
+  const { resetMissionList } = useMissions();
 
   async function logoutHandler() {
     await signOut({ redirect: false });
-    console.log(status);
-    if (status === 'authenticated') router.replace('/login');
+    if (status === 'authenticated') {
+      router.replace('/login');
+      resetHeroList();
+      resetMissionList();
+    }
   }
-  const onClick = () => {
-    console.log('click');
-  };
+
   return (
     <div className={styles.linkContainer}>
       <Link
         href={'/missions'}
         size={'lg'}
         selected={currentPage === '/missions'}
-        // onClick={onClick}
       >
         임무목록
       </Link>


### PR DESCRIPTION


### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
ex) close #117
<br>
<br>

### 3️⃣ 변경 사항
- 다른 아이디로 로그인시 이전 user의 herolist, missionlist가 전역에 저장되어 있는 상태여서 현 유저의 컨텐트가 렌더링되기 전에 이전 유저의 컨텐츠가 잠시 보이는 문제가 발생
- 로그아웃시 herolist, missionlist 상태 리셋하는 방식으로 해결
<br>
<br>
