### PR TITLE
fix: Modify text in login, signup page

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,12 +7,11 @@ import Link from 'next/link';
 import router from 'next/router';
 import { getSession, signIn } from 'next-auth/react';
 import { GetServerSideProps } from 'next';
-
 interface IinputValue {
   [key: string]: { value: string; isDirty: boolean };
 }
 
-export default function Signup() {
+export default function Signin() {
   const [inputValue, setInputValue] = useState<IinputValue>({});
   const [serverError, setServerError] = useState({ id: '', message: '' });
 
@@ -28,7 +27,7 @@ export default function Signup() {
       id: 'password',
       type: 'password',
       errMsg: '영어, 숫자, 특수기호 8~16 글자 입력해주세요',
-      labelText: '비번번호 :',
+      labelText: '비밀번호 :',
       regex:
         /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,16}$/,
     },
@@ -36,11 +35,10 @@ export default function Signup() {
 
   const handleSubmit = async () => {
     const response = await signIn('credentials', {
-      redirect: false, // 로그인 실패시 페이지 이동을 방지하기 위해 redirect: false
+      redirect: false,
       id: inputValue.id.value,
       password: inputValue.password.value,
     });
-
     if (!response?.error) {
       router.replace('/herolist');
     } else {
@@ -89,6 +87,7 @@ export default function Signup() {
         handleChange={handleChange}
         serverError={serverError}
         className={styles.signinGap}
+        buttonText="로그인"
       ></AuthForm>
       <PWAInstallButton />
       <p className={styles.signinNav}>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -29,7 +29,7 @@ export default function Signup() {
       id: 'password',
       type: 'password',
       errMsg: '영어, 숫자, 특수기호 8~16 글자 입력해주세요',
-      labelText: '비번번호 :',
+      labelText: '비밀번호 :',
       regex:
         /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,16}$/,
     },
@@ -95,6 +95,7 @@ export default function Signup() {
         handleChange={handleChange}
         serverError={serverError}
         className={styles.signupGap}
+        buttonText="회원가입"
       ></AuthForm>
       <p className={styles.signupNav}>
         <span className={styles.signupGuide}>이미 회원이시라면?</span>


### PR DESCRIPTION


### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
ex) close #120
<br>
<br>

### 3️⃣ 변경 사항
- AuthForm 컴포넌트의 buttonText props를 사용하여 로그인 페이지 버튼에 올바른 텍스트 기입
- 오타 수정 - 비번번호 -> 비밀번호
<br>
<br>

