### PR TITLE
refactor: Add theme color

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,17 +6,19 @@
   --grayscale-snow: #f2f2f2;
   --grayscale-white: #ffffff;
 
-  --color-main-orange-700: #ffc800;
-  --color-main-orange-600: #ffd94d;
-  --color-main-orange-500: #ffe480;
-  --color-main-orange-400: #ffefb3;
-  --color-main-orange-300: #fff4cc;
-  --color-main-orange-200: #fffae5;
+  --color-main-red: #FF6B6B;
+  --color-main-yellow: #FFD93D;
+  --color-main-green: #6BCB77;
+  --color-main-skyblue: #4D96FF;
+  --color-main-blue: #1453BF;
+  --color-main-pupple: #8E6AFF;
+  --color-main-pink: #FB82CE;
 
-  --color-main-active: #c19802;
-  --color-main-hover: #c19802;
+  --color-main-background: #EFF5FF;
+  --color-main-active: #4DBFFF;
 
-  --color-green: #67e774;
+  --color-btn-default: #8FADE3;
+  --color-btn-hover: #1453BF;
 
   --spacing-xs: 0.5rem; /* 8px */
   --spacing-sm: 1rem; /* 16px */
@@ -39,7 +41,6 @@
   --border-radius-lg: 6.25rem; /* 100px */
 
   --shadow-default: 1px 3px 4px rgba(0, 0, 0, 0.25);
-  --shadow-blur: 2px 2px 10px #d9cc9e;
 
   --transition-slow: 1s;
   --transition-default: 0.5s;


### PR DESCRIPTION
주색상, 보조색상 수정 및 추가

### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
이슈없음..

### 3️⃣ 변경 사항
피그마 시안에 맞춰 테마 css 수정하였습니다. 
- 주색상 추가
   - --color-main-red: #FF6B6B;
   ![image](https://user-images.githubusercontent.com/89028068/216802252-75166ee9-e2c7-4df9-ae2a-27725575b133.png)

   - --color-main-yellow: #FFD93D;
   ![image](https://user-images.githubusercontent.com/89028068/216802258-e1f2eacd-0e48-475b-8d7c-ac0d12ade83b.png)

   - --color-main-green: #6BCB77;
   ![image](https://user-images.githubusercontent.com/89028068/216802269-455806d2-b282-4b67-824c-5a90307b1e2d.png)

   - --color-main-skyblue: #4D96FF;
   ![image](https://user-images.githubusercontent.com/89028068/216802274-3cd3e7ce-8e83-4369-aa4e-11d87358b5e2.png)

   - --color-main-blue: #1453BF;
   ![image](https://user-images.githubusercontent.com/89028068/216802276-5ceb4f99-ec27-4cc7-969f-6d7b3fa03273.png)

   - --color-main-pupple: #8E6AFF;
   ![image](https://user-images.githubusercontent.com/89028068/216802295-5067673d-d171-424f-84a3-fb3ca1a6bf50.png)

   - --color-main-pink: #FB82CE;
   ![image](https://user-images.githubusercontent.com/89028068/216802295-5067673d-d171-424f-84a3-fb3ca1a6bf50.png)

   - --color-main-background: #EFF5FF;
   ![image](https://user-images.githubusercontent.com/89028068/216802298-aacbc6e1-39ba-46bf-9bca-f256e3cea68c.png)

   - --color-main-active: #4DBFFF;
   ![image](https://user-images.githubusercontent.com/89028068/216802309-8dcb6a4b-de1a-4582-abe8-5e31043693df.png)


- 버튼 색상 추가 
   - --color-btn-default: #8FADE3;  
   ![image](https://user-images.githubusercontent.com/89028068/216802313-e5333e3f-3bce-454d-bc5d-3b1c9a92965f.png)

   - --color-btn-hover: #1453BF;
   ![image](https://user-images.githubusercontent.com/89028068/216802317-36e5005f-528e-4e17-b3f7-d4fb7a8f9daa.png)


- 그림자 색상 제거
   - --shadow-default: 1px 3px 4px rgba(0, 0, 0, 0.25); 
   ![image](https://user-images.githubusercontent.com/89028068/216802332-70b2c524-2bba-4f2e-a1ca-eeecb0146d35.png)

   - 위 그림자만 남겨놓고 블러처리 그림자는 지웠습니다. 디자인통일을 위해서.. 


<br>
<br>

### 4️⃣ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
