### PR TITLE
feat: Implement edit, remove, pagination API

### DIFF
--- a/src/pages/api/groups/[groupId]/heroes/[heroId].ts
+++ b/src/pages/api/groups/[groupId]/heroes/[heroId].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { dbConnect } from '@/utils/server';
-import { Hero } from '@/models/index';
+import { Hero, Mission } from '@/models/index';
 
 type Data = {
   statusCode: number;
@@ -18,8 +18,12 @@ export default async function handler(
   await dbConnect();
 
   try {
-    if (method === 'DELETE') {
-      Hero.findOneAndDelete({ _id: req.query.heroId }).exec();
+    if (method === 'PATCH') {
+      Hero.findOneAndUpdate(
+        { _id: req.query.heroId },
+        { $set: { ...req.body } }
+      ).exec();
+
       return res.status(200).json({
         statusCode: 200,
         body: {


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
ex) close #142
<br>
<br>

### 3️⃣ 변경 사항
- hero 수정 api 
	- heroId를 통해 해당 히어로를 찾고 req.body에 실려온 값으로 히어로를 업데이트시킨다.
	- 미구현
	    - 이미지 서버 연동하여 이미지를 삭제하고 새로운 이미지로 업데이트하는 과정 필요

	       
- 히어로 삭제 api 
	- 히어로 삭제시 3가지 기능 수행
		- heroId로 찾은 히어로 삭제
		- 해당 히어로가 발행한 임무 삭제
		- 해당 히어로가 수락한 임무의 receivers 배열에서 삭제될 히어로의 heroId를 제거
	- 미구현
		- 히어로 삭제시 이미지 서버에서 해당 히어로의 이미지 삭제
		
- pagination api 
	- 쿼리 스트링을 이용하여 구현
		- page: 받아올 페이지 넘버
		- limit: 한 페이지당 받아올 히어로의 수
<br>
<br>
