### PR TITLE
feat: Implement client session handling instead of server side session handling 

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,15 +1,34 @@
 import type { AppProps } from 'next/app';
-import { SessionProvider } from 'next-auth/react';
-import Head from 'next/head';
+import { SessionProvider, useSession } from 'next-auth/react';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { ErrorBoundary } from '@/components';
+import Head from 'next/head';
+import { NextComponentType, NextPageContext } from 'next';
+import { AuthEnabledComponentConfig } from 'next/dist/shared/lib/utils';
+import { useRouter } from 'next/router';
+import { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import '../../public/fonts/style.css';
 import '../styles/globals.css';
 
 const queryClient = new QueryClient();
 
-export default function App({ Component, pageProps }: AppProps) {
+type AppAuthProps = AppProps & {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Component: NextComponentType<NextPageContext, any, {}> &
+    Partial<AuthEnabledComponentConfig>;
+};
+interface IAuth {
+  entrance:
+    | 'notLoggedIn'
+    | 'loggedIn'
+    | 'sessionLoggedIn'
+    | 'notSessionLoggedIn'
+    | 'notEntered';
+  redirection: string;
+  secondRedirection?: string;
+}
+export default function App({ Component, pageProps }: AppAuthProps) {
   return (
     <ErrorBoundary>
       <RecoilRoot>
@@ -22,11 +41,49 @@ export default function App({ Component, pageProps }: AppProps) {
                   content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no"
                 />
               </Head>
-              <Component {...pageProps} />
+              <Auth auth={Component.auth as IAuth}>
+                <Component {...pageProps} />
+              </Auth>
             </>
           </SessionProvider>
         </QueryClientProvider>
       </RecoilRoot>
     </ErrorBoundary>
   );
+}
+
+export type AuthProps = {
+  auth: IAuth;
+  children: ReactNode;
+};
+function Auth({ auth, children }: AuthProps): any {
+  const router = useRouter();
+  const { status } = useSession();
+  if (status === 'loading') {
+    return <div>Loading...</div>;
+  }
+  const adminId = sessionStorage.getItem('admin');
+  switch (auth.entrance) {
+    case 'notEntered':
+      if (status === 'authenticated')
+        router.replace(auth.redirection as string);
+      else router.replace(auth.secondRedirection as string);
+      break;
+    case 'loggedIn':
+      if (status === 'authenticated') return children;
+      else router.replace(auth.redirection as string);
+      break;
+    case 'notLoggedIn':
+      if (status === 'unauthenticated') return children;
+      else router.replace(auth.redirection as string);
+      break;
+    case 'sessionLoggedIn':
+      if (adminId) return children;
+      else router.replace(auth.redirection as string);
+      break;
+    case 'notSessionLoggedIn':
+      if (!adminId) return children;
+      else router.replace(auth.redirection as string);
+      break;
+  }
 }

--- a/src/pages/herolist/index.tsx
+++ b/src/pages/herolist/index.tsx
@@ -36,20 +36,7 @@ export default function Herolist() {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: { session },
-  };
+Herolist.auth = {
+  entrance: 'loggedIn',
+  redirection: '/login', // redirect to this url
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,28 +1,11 @@
-import Herolist from '@/pages/herolist';
-import { GetServerSideProps } from 'next';
-import { getSession } from 'next-auth/react';
 import styles from '../styles/Home.module.css';
 
 export default function Home() {
   return <div className={styles.container}></div>;
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    redirect: {
-      destination: '/herolist',
-      permanent: false,
-    },
-  };
+Home.auth = {
+  entrance: 'notEntered',
+  redirection: '/herolist',
+  secondRedirection: '/login',
 };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { useState } from 'react';
-import { GetServerSideProps } from 'next';
-import { getSession, signIn } from 'next-auth/react';
+import { GetStaticProps } from 'next';
+import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -10,13 +10,15 @@ import {
   Input,
   ValidationErrorMessage,
   ErrorMessage,
-} from '@/components/Auth';
-import { Title, Slide, PWAInstallButton, Button } from '@/components/common';
+  Title,
+  Slide,
+  PWAInstallButton,
+  Button,
+} from '@/components/common';
 import { useForm } from '@/hooks';
 import styles from '@styles/Login.module.css';
 
 export default function Signin() {
-  // const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
   const [serverError, setServerError] = useState({ id: '', message: '' });
   const { errors, touched, handleSubmit, getFieldProps, isValid } = useForm({
@@ -45,9 +47,7 @@ export default function Signin() {
         id: values.id,
         password: values.password,
       });
-      if (!response?.error) {
-        router.replace('/herolist');
-      } else {
+      if (response?.error) {
         switch (response.error) {
           case 'no-id':
             setServerError(() => ({
@@ -66,19 +66,6 @@ export default function Signin() {
     },
   });
 
-  // useEffect(() => {
-  //   getSession().then((session) => {
-  //     if (session) {
-  //       // 로그인했으면 홈으로
-  //       router.replace('/herolist');
-  //     } else {
-  //       // 로그인 안했으면 authform 보여줌
-  //       setIsLoading(false);
-  //     }
-  //   });
-  // }, [router]);
-
-  // if (isLoading) return <p>Loading...</p>;
   return (
     <>
       <Head>
@@ -98,12 +85,13 @@ export default function Signin() {
             labelText="아이디 :"
             border="round"
             getFieldProps={getFieldProps}
-          >
-            <ValidationErrorMessage
-              touched={touched}
-              errors={errors}
-            ></ValidationErrorMessage>
-          </Input>
+          />
+          <ValidationErrorMessage
+            name="id"
+            touched={touched}
+            errors={errors}
+            className={styles.serverErrorMsg}
+          ></ValidationErrorMessage>
           <ErrorMessage
             error={serverError.id === 'no-id' ? serverError.message : ''}
             className={styles.serverErrorMsg}
@@ -115,12 +103,13 @@ export default function Signin() {
             labelText="비밀번호 :"
             border="round"
             getFieldProps={getFieldProps}
-          >
-            <ValidationErrorMessage
-              touched={touched}
-              errors={errors}
-            ></ValidationErrorMessage>
-          </Input>
+          />
+          <ValidationErrorMessage
+            name="password"
+            touched={touched}
+            errors={errors}
+            className={styles.serverErrorMsg}
+          ></ValidationErrorMessage>
           <ErrorMessage
             error={serverError.id === 'wrong-id' ? serverError.message : ''}
             className={styles.serverErrorMsg}
@@ -130,28 +119,30 @@ export default function Signin() {
           </Button>
         </Form>
         <PWAInstallButton />
-        <p className={styles.signinNav}>
-          <span className={styles.signinGuide}>아직 회원이 아니시라면?</span>
-          <Link href="/signup" legacyBehavior>
-            <a className={styles.signinLink}>{'회원가입'}</a>
-          </Link>
-        </p>
+        <ul className={styles.signinGuideList}>
+          <li className={styles.signinNav}>
+            <span className={styles.signinGuide}>아직 회원이 아니시라면?</span>
+            <Link href="/signup" legacyBehavior>
+              <a className={styles.signinLink}>{'회원가입'}</a>
+            </Link>
+          </li>
+          <li className={styles.adminLink}>
+            <Link href="/adminlogin" legacyBehavior>
+              <a className={styles.signinLink}>{'관리자 페이지'}</a>
+            </Link>
+          </li>
+        </ul>
       </Slide>
     </>
   );
 }
+Signin.auth = {
+  entrance: 'notLoggedIn',
+  redirection: '/herolist', // redirect to this url
+};
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (session) {
-    return {
-      redirect: {
-        destination: '/herolist',
-        permanent: false,
-      },
-    };
-  }
-
-  return { props: { session } };
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {},
+  };
 };

--- a/src/pages/missionlist/[missionId]/index.tsx
+++ b/src/pages/missionlist/[missionId]/index.tsx
@@ -3,14 +3,14 @@ import Head from 'next/head';
 import { BeatLoader } from 'react-spinners';
 import { MissionCard } from '@/components/MissionList';
 import { useGetMission } from '@/apis';
+import { useRouter } from 'next/router';
 
-interface MissiondetailProps {
-  missionId: string;
-}
-
-export default function MissionDetail({ missionId }: MissiondetailProps) {
+export default function MissionDetail() {
   const groupId = '1';
-  const { data: mission } = useGetMission(groupId, missionId);
+  const router = useRouter();
+  const { missionId } = router.query;
+  console.log('missionId : ', missionId);
+  const { data: mission } = useGetMission(groupId, missionId as string);
 
   if (mission === undefined) {
     return <BeatLoader />;
@@ -27,15 +27,7 @@ export default function MissionDetail({ missionId }: MissiondetailProps) {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const {
-    query: { missionId },
-  } = context;
-
-  return {
-    props: {
-      missionId,
-    },
-  };
+MissionDetail.auth = {
+  entrance: 'loggedIn',
+  redirection: '/login', // redirect to this url
 };

--- a/src/pages/missionlist/index.tsx
+++ b/src/pages/missionlist/index.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import { getSession } from 'next-auth/react';
 import { BeatLoader } from 'react-spinners';
 import { Nav, Slide } from '@/components/common';
 import { MissionItem } from '@/components/MissionList';
@@ -41,20 +39,7 @@ export default function MissionList() {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: { session },
-  };
+MissionList.auth = {
+  entrance: 'loggedIn',
+  redirection: '/login', // redirect to this url
 };

--- a/src/pages/missionlist/newmission/index.tsx
+++ b/src/pages/missionlist/newmission/index.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { MissionCard } from '@/components/MissionList';
 import { defaultMission } from '@/states';
+import { GetStaticProps } from 'next';
 
 export default function NewMission() {
   return (
@@ -14,3 +15,13 @@ export default function NewMission() {
     </>
   );
 }
+NewMission.auth = {
+  entrance: 'loggedIn',
+  redirection: '/login', // redirect to this url
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {},
+  };
+};

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,5 +1,4 @@
-import { GetServerSideProps } from 'next';
-import { getSession } from 'next-auth/react';
+import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import { AnimatePresence } from 'framer-motion';
 import { Register } from '@/components/Register';
@@ -16,20 +15,12 @@ export default function HeroRegister() {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
-  }
-
+HeroRegister.auth = {
+  entrance: 'loggedIn',
+  redirection: '/login', // redirect to this url
+};
+export const getStaticProps: GetStaticProps = async () => {
   return {
-    props: { session },
+    props: {},
   };
 };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { useState } from 'react';
-import { GetServerSideProps } from 'next';
-import { getSession } from 'next-auth/react';
+import { GetStaticProps } from 'next';
 import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -11,13 +10,14 @@ import {
   Input,
   ValidationErrorMessage,
   ErrorMessage,
-} from '@/components/Auth';
-import { Title, Slide, Button } from '@/components/common';
+  Title,
+  Slide,
+  Button,
+} from '@/components/common';
 import { useForm } from '@/hooks';
 import styles from '@styles/Signup.module.css';
 
 export default function Signup() {
-  // const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
   const [serverError, setServerError] = useState({ id: '', message: '' });
   const { errors, touched, handleSubmit, getFieldProps, isValid } = useForm({
@@ -69,20 +69,6 @@ export default function Signup() {
       }
     },
   });
-
-  // useEffect(() => {
-  //   getSession().then((session) => {
-  //     if (session) {
-  //       // 로그인했으면 홈으로
-  //       router.replace('/herolist');
-  //     } else {
-  //       // 로그인 안했으면 authform 보여줌
-  //       setIsLoading(false);
-  //     }
-  //   });
-  // }, [router]);
-
-  // if (isLoading) return <p>Loading...</p>;
 
   return (
     <>
@@ -159,18 +145,13 @@ export default function Signup() {
     </>
   );
 }
+Signup.auth = {
+  entrance: 'notLoggedIn',
+  redirection: '/herolist', // redirect to this url
+};
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession({ req: context.req });
-
-  if (session) {
-    return {
-      redirect: {
-        destination: '/herolist',
-        permanent: false,
-      },
-    };
-  }
-
-  return { props: { session } };
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {},
+  };
 };


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
ex) close #153
<br>
<br>

### 3️⃣ 변경 사항
## client session handling
serverSideProps를 사용하여 server side에서 session check를 하는 대신에 client 단에서 session check를 한다.
client session 확인하기 위해서는 각 페이지마다 Component.auth를 설정해주어야 한다.

### 1. auth 설명
- entrance (필수) : 페이지 입장 조건
    - notLoggedIn : session이 없을 경우에만 입장 가능한 페이지임을 표시
    - loggedIn : session이 있을 경우에만 입장 가능한 페이지임을 표시
    - sessionLoggedIn : session 스토리지에 'admin'이 존재할 경우에만 입장 가능한 페이지임을 표시 (관리자 로그인 용)
    - notSessionLoggedIn : session 스토리지에 'admin'이 존재하지 않을 경우에만 입장 가능한 페이지임을 표시 (관리자 로그인 용)
    - notEntered : 입장 불가 페이지임을 표시
- redirection (필수) : 해당 페이지에 입장하지 못할 경우에 redirect될 페이지
- seconRedirection (선택) : 두 번째 redirect 주소


### 2. 타입 설정
- node_modules/next/dist/shared/lib/utils.d.ts 하단에 아래 코드 추가

```
export interface AuthEnabledComponentConfig {
    auth: {
        entrance: 'loggedIn' | 'notLoggedIn' | 'sessionLoggedIn' | 'notSessionLoggedIn' | 'notEntered',
        redirection: string,
	secondRedirection?: string
    };
}

// eslint-disable-next-line @typescript-eslint/no-explicit-any
export type ComponentWithAuth<PropsType = any> = React.FC<PropsType> &
AuthEnabledComponentConfig;
```

참고 : https://github.com/nextauthjs/next-auth/issues/1210


### 3. 각페이지에 client session handling 적용

<br>
<br>

